### PR TITLE
add codiceIPA to publiccode.yml

### DIFF
--- a/publiccode.yml
+++ b/publiccode.yml
@@ -133,6 +133,8 @@ it:
     cie: false
     pagopa: false
     spid: false
+  riuso:
+    codiceIPA: unical
 landingURL: 'https://github.com/UniversitaDellaCalabria/uniAuth'
 legal:
   authorsFile: >-


### PR DESCRIPTION
Questa PR aggiunge il `codiceIPA` al `publiccode.yml` necessario per la corretta indicizzazione sul catalogo Developers Italia.

Grazie @francesco-filicetti 