### PR TITLE
rebased to newest commit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,88 @@
+ARG USER=that-user
+ ARG PASS=that-password
+ ARG HOST=%
+ ARG DB=uniauth
+
+ ARG COUNTRY=na
+ ARG STATE=na
+ ARG LOCATION=na
+ ARG ORGANIZATION=na
+ ARG ORGANIZATIONAL_UNIT=na
+ ARG COMMON_NAME=na
+
+ ARG VIRTUAL_ENV=/opt/venv
+ ARG PATH="$VIRTUAL_ENV/bin:$PATH"
+
+
+ FROM python:3.8-slim-buster as builder
+
+ RUN apt update
+ RUN apt install -y \
+ 	git \
+ 	xmlsec1 \
+ 	mariadb-server \
+ 	libmariadb-dev \
+ 	libssl-dev \
+ 	libmariadb-dev-compat \
+ 	libsasl2-dev \
+ 	libldap2-dev \
+ 	gcc
+
+
+ FROM builder as virtenv
+
+ RUN mkdir /app
+ WORKDIR /app
+
+ RUN pip install \
+	virtualenv \
+ 	django-sass-processor \
+ 	multildap \
+ 	ldap3 \
+ 	python-ldap \
+ 	design-django-theme \
+ 	django-unical-bootstrap-italia \
+ 	django-admin-rangefilter \
+ 	pycountry
+
+
+ ARG VIRTUAL_ENV
+ ENV VIRTUAL_ENV=$VIRTUAL_ENV
+ RUN python3 -m venv $VIRTUAL_ENV
+ ARG PATH
+ ENV PATH=$PATH
+ COPY ./src/requirements-dev.txt .
+ RUN pip install -r requirements-dev.txt
+
+ COPY src .
+
+ ARG USER
+ ENV USER=$USER
+ ARG PASS
+ ENV PASS=$PASS
+ ARG HOST
+ ENV HOST=$HOST
+ ARG DB
+ ENV DB=$DB
+ RUN service mysql restart \
+ 	&& mysql -u root -e "\
+ CREATE USER IF NOT EXISTS work@users-iMac.local IDENTIFIED BY ;\
+ CREATE DATABASE IF NOT EXISTS ${DB} CHARACTER SET = utf8 COLLATE = utf8_general_ci;\
+ GRANT ALL PRIVILEGES ON ${DB}.* TO work@users-iMac.local;"
+
+
+ ARG COUNTRY
+ ARG STATE
+ ARG LOCATION
+ ARG ORGANIZATION
+ ARG ORGANIZATIONAL_UNIT
+ ARG COMMON_NAME
+ RUN openssl \
+ 	req -nodes -new -x509 \
+ 	-newkey rsa:2048 \
+ 	-days 3650 \
+ 	-keyout certificates/private.key \
+ 	-out certificates/public.cert \
+ 	-subj "/C=$COUNTRY/ST=$STATE/L=$LOCATION/O=$ORGANIZATION/OU=$ORGANIZATIONAL_UNIT/CN=$COMMON_NAME"
+
+


### PR DESCRIPTION
I am just providing this as a new basis for further discussion:

- documentation
  there seems a lot of documentation, where do you see it the best fit to add docker related documentation?

- example
  I have not managed to successfully start an example of the service. steps I took:
  - docker build . && docker run -p 9000:9000 -it {some random ID} bash
  - mv settingslocal.py.example and idp_djangowhatnot.py.exmaple to "not".example
  - ./manage.py migrate
  - ./manage.py createsuperuser
  - ./manage.py runserver 0.0.0.0:9000
  
  on the resulting server, I can access "/admin" and that's it.
  - I can not test saml auth flow
  - I can not test admin settings (for no effect on saml auth flow)
  - I do not see an example page ( for / results in a debug version of 404)
  etc.
  
  at this point I am asking myself, what is the scope of this project. maybe I did not understand and my expectations
  are blown out of proportion. I somehow expected a working saml example.